### PR TITLE
[Android] requestPermissions() throws NullPointerException on Android 10+ (API 29+)

### DIFF
--- a/android/src/main/java/app/capgo/pedometer/CapacitorPedometerPlugin.java
+++ b/android/src/main/java/app/capgo/pedometer/CapacitorPedometerPlugin.java
@@ -121,7 +121,7 @@ public class CapacitorPedometerPlugin extends Plugin implements SensorEventListe
     @PluginMethod
     public void requestPermissions(PluginCall call) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            if (getPermissionState(Manifest.permission.ACTIVITY_RECOGNITION) != PermissionState.GRANTED) {
+            if (getPermissionState("activityRecognition") != PermissionState.GRANTED) {
                 requestPermissionForAlias("activityRecognition", call, "permissionCallback");
             } else {
                 JSObject result = new JSObject();
@@ -206,14 +206,17 @@ public class CapacitorPedometerPlugin extends Plugin implements SensorEventListe
 
     private boolean hasActivityRecognitionPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            return getPermissionState(Manifest.permission.ACTIVITY_RECOGNITION) == PermissionState.GRANTED;
+            return getPermissionState("activityRecognition") == PermissionState.GRANTED;
         }
         return true; // No permission needed on older Android versions
     }
 
     private String getPermissionState() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            PermissionState state = getPermissionState(Manifest.permission.ACTIVITY_RECOGNITION);
+            PermissionState state = getPermissionState("activityRecognition");
+            if (state == null) {
+                return PERMISSION_PROMPT;
+            }
             switch (state) {
                 case GRANTED:
                     return PERMISSION_GRANTED;


### PR DESCRIPTION
Full disclosure, this bug fix has come from working with AI agents. The plugin kept throwing an error on my Pixel 9 and AI suggested this fix. It fixes the issue I was having, so I'm adding it here at your disposal. If anyone else has had this same issue please comment.

## Description:
Fixes a `NullPointerException` thrown from `permissionCallback` on Android 10+ that causes `requestPermissions()` to hang the JS Promise forever.

## Environment

- Plugin: `@capgo/capacitor-pedometer@8.0.27`
- Capacitor: `8.3.1`
- Android: 16 (Pixel 9), `targetSdk = 36`

## Stack trace

```
  java.lang.NullPointerException: Attempt to invoke virtual method
    'int com.getcapacitor.PermissionState.ordinal()' on a null object reference
      at app.capgo.pedometer.CapacitorPedometerPlugin.getPermissionState(CapacitorPedometerPlugin.java:217)
      at app.capgo.pedometer.CapacitorPedometerPlugin.permissionCallback(CapacitorPedometerPlugin.java:142)
      at com.getcapacitor.Plugin.triggerPermissionCallback(Plugin.java:140)
      ...
```

## Cause

`Plugin.getPermissionState(String)` looks up state by the **alias** declared in `@CapacitorPlugin`'s `permissions` array. The plugin already uses the correct alias `"activityRecognition"` in `requestPermissionForAlias(...)` on line 125, but three other call sites pass the raw `Manifest.permission.ACTIVITY_RECOGNITION` constant, which doesn't match any alias and returns `null`. The downstream `switch(state)` then NPEs on `.ordinal()`.

## Fix

Three one-line replacements + a defensive null-guard:

- L124, L209, L216: `getPermissionState(Manifest.permission.ACTIVITY_RECOGNITION)` →
`getPermissionState("activityRecognition")`
- L216: add `if (state == null) return PERMISSION_PROMPT;` before the switch

## Verification

Tested on Pixel 9 / Android 16 (`targetSdk=36`). `requestPermissions()` now resolves correctly, the OS permission
dialog fires when needed, and `startMeasurementUpdates()` succeeds.